### PR TITLE
Fix homepage in gemspec

### DIFF
--- a/redfish_client.gemspec
+++ b/redfish_client.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["tadej.borovsak@xlab.si"]
 
   spec.summary       = "Simple Redfish client library"
-  spec.homepage      = "https://github.com/xlab-si/redfish-client-ruby"
+  spec.homepage      = "https://github.com/xlab-steampunk/redfish-client-ruby"
   spec.license       = "Apache-2.0"
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
The Homepage link in Rubygems is not working as it’s pointing to the old repo home.