### PR TITLE
Add a use_session parameter to force basic auth usage

### DIFF
--- a/lib/redfish_client.rb
+++ b/lib/redfish_client.rb
@@ -11,10 +11,11 @@ module RedfishClient
   # @param url [String] base URL of Redfish API
   # @param prefix [String] Redfish API prefix
   # @param verify [Boolean] verify certificates for https connections
+  # @param use_session [Boolean] Use a session for authentication
   # @param use_cache [Boolean] cache API responses
-  def self.new(url, prefix: "/redfish/v1", verify: true, use_cache: true)
+  def self.new(url, prefix: "/redfish/v1", verify: true, use_cache: true, use_session: true)
     cache = (use_cache ? Hash : NilHash).new
-    con = Connector.new(url, verify: verify, cache: cache)
+    con = Connector.new(url, verify: verify, cache: cache, use_session: use_session)
     Root.new(con, oid: prefix)
   end
 end

--- a/lib/redfish_client/connector.rb
+++ b/lib/redfish_client/connector.rb
@@ -47,8 +47,9 @@ module RedfishClient
     #
     # @param url [String] base url of the Redfish service
     # @param verify [Boolean] verify SSL certificate of the service
+    # @param use_session [Boolean] Use a session for authentication
     # @param cache [Object] cache backend
-    def initialize(url, verify: true, cache: nil)
+    def initialize(url, verify: true, cache: nil, use_session: true)
       @url = url
       @headers = DEFAULT_HEADERS.dup
       middlewares = Excon.defaults[:middlewares] +
@@ -57,6 +58,7 @@ module RedfishClient
                               ssl_verify_peer: verify,
                               middlewares: middlewares)
       @cache = cache || NilHash.new
+      @use_session = use_session
     end
 
     # Add HTTP headers to the requests made by the connector.
@@ -157,7 +159,7 @@ module RedfishClient
       @username = username
       @password = password
       @auth_test_path = auth_test_path
-      @session_path = session_path
+      @session_path = @use_session ? session_path : nil
     end
 
     # Authenticate against the service.

--- a/spec/redfish_client/connector_spec.rb
+++ b/spec/redfish_client/connector_spec.rb
@@ -254,12 +254,21 @@ RSpec.describe RedfishClient::Connector do
       connector = described_class.new("http://auth.demo")
       expect { connector.set_auth_info("user", "pass", "/test") }
         .not_to raise_error
+      expect(connector.instance_variable_get(:@session_path)).to be_nil
     end
 
     it "sets session auth info" do
       connector = described_class.new("http://auth.demo")
       expect { connector.set_auth_info("user", "pass", "/test", "/sessions") }
         .not_to raise_error
+      expect(connector.instance_variable_get(:@session_path)).to eq('/sessions')
+    end
+
+    it "forces basic auth when requested" do
+      connector = described_class.new("http://auth.demo", use_session: false)
+      expect { connector.set_auth_info("user", "pass", "/test", "/sessions") }
+        .not_to raise_error
+      expect(connector.instance_variable_get(:@session_path)).to be_nil
     end
   end
 


### PR DESCRIPTION
It's important to clean up sessions because various Redfish implementations have a limit on the number of sessions. Forgetting to clean up can have a DoS effect.

Further testing showed that, at least in some implementations, there's a significant overhead on setting up a session for a single request while for multiple requests it's unclear if it provides benefit.

```
                                               user       system     total       real
curl on root without login:                    0.000457   0.000111   0.063841 (  0.719540)
curl on root with basic auth:                  0.000389   0.000095   0.048539 (  0.807732)
curl on root with session auth:                0.000479   0.000116   0.186354 (  2.672784)
curl on multiple endpoints with session auth:  0.000859   0.000209   0.480265 ( 10.841015)
curl on multiple endpoints with basic auth:    0.000726   0.000177   0.367814 (  8.859796)

                                               user       system     total       real
curl on root without login:                    0.000427   0.000096   0.057136 (  0.687104)
curl on root with basic auth:                  0.000467   0.000104   0.048592 (  0.862687)
curl on root with session auth:                0.000421   0.000094   0.178445 (  2.568848)
curl on multiple endpoints with session auth:  0.001025   0.000229   0.576333 (  8.948681)
curl on multiple endpoints with basic auth:    0.000000   0.001359   0.450287 ( 10.347542)

                                               user       system      total      real
curl on root without login:                    0.000448   0.000073   0.054231 (  0.678578)
curl on root with basic auth:                  0.000406   0.000065   0.049842 (  0.867248)
curl on root with session auth:                0.000477   0.000078   0.178306 (  2.403250)
curl on multiple endpoints with session auth:  0.000971   0.000158   0.518806 (  9.558119)
curl on multiple endpoints with basic auth:    0.001447   0.000000   0.405758 ( 10.668350)
```

(from https://github.com/theforeman/smart-proxy/pull/896#issuecomment-2119009292)

This implements a `use_session` parameter to force basic auth usage, giving control over this.

Fixes #7

I'll note I don't have access to Redfish hardware right now to test this out, so I've only relied on the tests.