### PR TITLE
Compatibility with excon 1.x

### DIFF
--- a/redfish_client.gemspec
+++ b/redfish_client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1"
 
-  spec.add_runtime_dependency "excon", "~> 0.71"
+  spec.add_runtime_dependency "excon", ">= 0.71", "< 2"
   spec.add_runtime_dependency "server_sent_events", "~> 0.1"
 
   spec.add_development_dependency "rake", ">= 11.0"


### PR DESCRIPTION
Version 1.x has been released and it doesn't appear any API changes were relevant so this is just a simple broadening of the dependency.