### PR TITLE
Fix basic auth encoding for long credentials

### DIFF
--- a/lib/redfish_client/connector.rb
+++ b/lib/redfish_client/connector.rb
@@ -324,7 +324,7 @@ module RedfishClient
     end
 
     def basic_login
-      payload = Base64.encode64("#{@username}:#{@password}").strip
+      payload = Base64.strict_encode64("#{@username}:#{@password}")
       add_headers(BASIC_AUTH_HEADER => "Basic #{payload}")
       return if auth_valid?
 

--- a/spec/redfish_client/connector_spec.rb
+++ b/spec/redfish_client/connector_spec.rb
@@ -324,6 +324,19 @@ RSpec.describe RedfishClient::Connector do
       expect(stub).to have_been_requested.once
     end
 
+    it "does not add newlines to long basic auth credentials" do
+      password = "p" * 100
+      expected_header = "Basic #{Base64.strict_encode64("user:#{password}")}"
+      stub = stub_request(:get, "http://auth.demo/test")
+        .with(headers: { "Authorization" => expected_header })
+
+      connector = described_class.new("http://auth.demo")
+      connector.set_auth_info("user", password, "/test")
+      connector.login
+
+      expect(stub).to have_been_requested.once
+    end
+
     it "raises error if basic auth fails" do
       stub_request(:get, "http://auth.demo/test").to_return(status: 401)
       connector = described_class.new("http://auth.demo")


### PR DESCRIPTION
Base64.encode64 will input \n characters if the input is too long, so just stripping the result is not enough. Base64.strict_encode64 does not insert these line breaks, and should therefore be used here.